### PR TITLE
feat(spanner): exporting transaction._rolled_back as transaction.rolled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@
 
 [1]: https://pypi.org/project/google-cloud-spanner/#history
 
+## [1.14.0](https://www.github.com/googleapis/python-spanner/compare/v1.13.0...v1.14.0) (2020-01-31)
+
+
+### Features
+
+* **spanner:** add deprecation warnings; add field_mask to get_instance; add endpoint_uris to Instance proto; update timeouts; make mutations optional for commits (via synth) ([62edbe1](https://www.github.com/googleapis/python-spanner/commit/62edbe12a0c5a74eacb8d87ca265a19e6d27f890))
+* **spanner:** add resource based routing implementation ([#10183](https://www.github.com/googleapis/python-spanner/issues/10183)) ([e072d5d](https://www.github.com/googleapis/python-spanner/commit/e072d5dd04d58fff7f62ce19ce42e906dfd11012))
+* **spanner:** un-deprecate resource name helper functions, add 3.8 tests (via synth) ([#10062](https://www.github.com/googleapis/python-spanner/issues/10062)) ([dbb79b0](https://www.github.com/googleapis/python-spanner/commit/dbb79b0d8b0c79f6ed1772f28e4eedb9d986b108))
+
+
+### Bug Fixes
+
+* be permssive about merging an empty struct ([#10079](https://www.github.com/googleapis/python-spanner/issues/10079)) ([cfae63d](https://www.github.com/googleapis/python-spanner/commit/cfae63d5a8b8332f8875307283da6075a544c838))
+* **spanner:** fix imports for doc samples ([#10283](https://www.github.com/googleapis/python-spanner/issues/10283)) ([55a21d9](https://www.github.com/googleapis/python-spanner/commit/55a21d97d0c863cbbbb2d973b6faa4aeba8e38bb))
+
 ## 1.13.0
 
 11-11-2019 15:59 PST

--- a/google/cloud/spanner_v1/pool.py
+++ b/google/cloud/spanner_v1/pool.py
@@ -503,7 +503,7 @@ class TransactionPingingPool(PingingPool):
             raise queue.Full
 
         txn = session._transaction
-        if txn is None or txn.committed or txn._rolled_back:
+        if txn is None or txn.committed or txn.rolled_back:
             session.transaction()
             self._pending_sessions.put(session)
         else:

--- a/google/cloud/spanner_v1/session.py
+++ b/google/cloud/spanner_v1/session.py
@@ -255,7 +255,7 @@ class Session(object):
             raise ValueError("Session has not been created.")
 
         if self._transaction is not None:
-            self._transaction._rolled_back = True
+            self._transaction.rolled_back = True
             del self._transaction
 
         txn = self._transaction = Transaction(self)

--- a/google/cloud/spanner_v1/transaction.py
+++ b/google/cloud/spanner_v1/transaction.py
@@ -36,7 +36,7 @@ class Transaction(_SnapshotBase, _BatchBase):
 
     committed = None
     """Timestamp at which the transaction was successfully committed."""
-    _rolled_back = False
+    rolled_back = False
     _multi_use = True
     _execute_sql_count = 0
 
@@ -58,7 +58,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         if self.committed is not None:
             raise ValueError("Transaction is already committed")
 
-        if self._rolled_back:
+        if self.rolled_back:
             raise ValueError("Transaction is already rolled back")
 
     def _make_txn_selector(self):
@@ -85,7 +85,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         if self.committed is not None:
             raise ValueError("Transaction already committed")
 
-        if self._rolled_back:
+        if self.rolled_back:
             raise ValueError("Transaction is already rolled back")
 
         database = self._session._database
@@ -105,7 +105,7 @@ class Transaction(_SnapshotBase, _BatchBase):
         api = database.spanner_api
         metadata = _metadata_with_prefix(database.name)
         api.rollback(self._session.name, self._transaction_id, metadata=metadata)
-        self._rolled_back = True
+        self.rolled_back = True
         del self._session._transaction
 
     def commit(self):

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ import setuptools
 
 name = "google-cloud-spanner"
 description = "Cloud Spanner API client library"
-version = "1.13.0"
+version = "1.14.0"
 # Should be one of:
 # 'Development Status :: 3 - Alpha'
 # 'Development Status :: 4 - Beta'

--- a/tests/unit/test_pool.py
+++ b/tests/unit/test_pool.py
@@ -837,7 +837,7 @@ def _make_transaction(*args, **kw):
 
     txn = mock.create_autospec(Transaction)(*args, **kw)
     txn.committed = None
-    txn._rolled_back = False
+    txn.rolled_back = False
     return txn
 
 

--- a/tests/unit/test_session.py
+++ b/tests/unit/test_session.py
@@ -463,7 +463,7 @@ class TestSession(unittest.TestCase):
         another = session.transaction()  # invalidates existing txn
 
         self.assertIs(session._transaction, another)
-        self.assertTrue(existing._rolled_back)
+        self.assertTrue(existing.rolled_back)
 
     def test_run_in_transaction_callback_raises_non_gax_error(self):
         from google.cloud.spanner_v1.proto.transaction_pb2 import (
@@ -506,7 +506,7 @@ class TestSession(unittest.TestCase):
         txn, args, kw = called_with[0]
         self.assertIsInstance(txn, Transaction)
         self.assertIsNone(txn.committed)
-        self.assertTrue(txn._rolled_back)
+        self.assertTrue(txn.rolled_back)
         self.assertEqual(args, ())
         self.assertEqual(kw, {})
 
@@ -561,7 +561,7 @@ class TestSession(unittest.TestCase):
         txn, args, kw = called_with[0]
         self.assertIsInstance(txn, Transaction)
         self.assertIsNone(txn.committed)
-        self.assertFalse(txn._rolled_back)
+        self.assertFalse(txn.rolled_back)
         self.assertEqual(args, ())
         self.assertEqual(kw, {})
 

--- a/tests/unit/test_transaction.py
+++ b/tests/unit/test_transaction.py
@@ -76,7 +76,7 @@ class TestTransaction(unittest.TestCase):
         self.assertIs(transaction._session, session)
         self.assertIsNone(transaction._transaction_id)
         self.assertIsNone(transaction.committed)
-        self.assertFalse(transaction._rolled_back)
+        self.assertFalse(transaction.rolled_back)
         self.assertTrue(transaction._multi_use)
         self.assertEqual(transaction._execute_sql_count, 0)
 
@@ -98,7 +98,7 @@ class TestTransaction(unittest.TestCase):
         session = _Session()
         transaction = self._make_one(session)
         transaction._transaction_id = self.TRANSACTION_ID
-        transaction._rolled_back = True
+        transaction.rolled_back = True
         with self.assertRaises(ValueError):
             transaction._check_state()
 
@@ -125,7 +125,7 @@ class TestTransaction(unittest.TestCase):
     def test_begin_already_rolled_back(self):
         session = _Session()
         transaction = self._make_one(session)
-        transaction._rolled_back = True
+        transaction.rolled_back = True
         with self.assertRaises(ValueError):
             transaction.begin()
 
@@ -187,7 +187,7 @@ class TestTransaction(unittest.TestCase):
         session = _Session()
         transaction = self._make_one(session)
         transaction._transaction_id = self.TRANSACTION_ID
-        transaction._rolled_back = True
+        transaction.rolled_back = True
         with self.assertRaises(ValueError):
             transaction.rollback()
 
@@ -203,7 +203,7 @@ class TestTransaction(unittest.TestCase):
         with self.assertRaises(RuntimeError):
             transaction.rollback()
 
-        self.assertFalse(transaction._rolled_back)
+        self.assertFalse(transaction.rolled_back)
 
     def test_rollback_ok(self):
         from google.protobuf.empty_pb2 import Empty
@@ -218,7 +218,7 @@ class TestTransaction(unittest.TestCase):
 
         transaction.rollback()
 
-        self.assertTrue(transaction._rolled_back)
+        self.assertTrue(transaction.rolled_back)
         self.assertIsNone(session._transaction)
 
         session_id, txn_id, metadata = api._rolled_back
@@ -244,7 +244,7 @@ class TestTransaction(unittest.TestCase):
         session = _Session()
         transaction = self._make_one(session)
         transaction._transaction_id = self.TRANSACTION_ID
-        transaction._rolled_back = True
+        transaction.rolled_back = True
         with self.assertRaises(ValueError):
             transaction.commit()
 
@@ -546,7 +546,7 @@ class TestTransaction(unittest.TestCase):
                 raise Exception("bail out")
 
         self.assertEqual(transaction.committed, None)
-        self.assertTrue(transaction._rolled_back)
+        self.assertTrue(transaction.rolled_back)
         self.assertEqual(len(transaction._mutations), 1)
 
         self.assertEqual(api._committed, None)


### PR DESCRIPTION
IPR  [13]
